### PR TITLE
Remove pycrypto dependencies

### DIFF
--- a/redsys/client.py
+++ b/redsys/client.py
@@ -51,7 +51,7 @@ class Client(object):
         return json.loads(base64.b64decode(parameters).decode('utf-8'))
 
     def encrypt_3DES(self, order):
-        pycrypto = DES3.new(base64.b64decode(self.secret_key), DES3.MODE_CBC, IV=b'\0\0\0\0\0\0\0\0')
+        pycrypto = DES3.new(base64.b64decode(self.secret_key).encode('utf-8'), DES3.MODE_CBC, IV=b'\0\0\0\0\0\0\0\0'.encode('utf-8'))
         if (sys.version_info > (3,0)):
             order_padded = order.ljust(16, u'\x00')
         else:

--- a/redsys/client.py
+++ b/redsys/client.py
@@ -51,13 +51,13 @@ class Client(object):
         return json.loads(base64.b64decode(parameters).decode('utf-8'))
 
     def encrypt_3DES(self, order):
-        pycrypto = DES3.new(base64.b64decode(self.secret_key).encode('utf-8'), DES3.MODE_CBC, IV=b'\0\0\0\0\0\0\0\0'.encode('utf-8'))
+        pycrypto = DES3.new(base64.b64decode(self.secret_key), DES3.MODE_CBC, IV=b'\0\0\0\0\0\0\0\0')
         if (sys.version_info > (3,0)):
             order_padded = order.ljust(16, u'\x00')
         else:
             order_padded = order.ljust(16, b'\0')
 
-        return pycrypto.encrypt(order_padded)
+        return pycrypto.encrypt(order_padded.encode('utf-8'))
 
     def sign_hmac256(self, encrypted_order, merchant_parameters):
         signature = hmac.new(encrypted_order, merchant_parameters, hashlib.sha256).digest()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='redsys',
-    version='0.2.6',
+    version='0.2.7',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,4 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['pycrypto>=2.6,<2.7']
 )


### PR DESCRIPTION
If you encode  to utf-8 the order_padded, you don't have: TypeError: Object type <class 'str'> cannot be passed to C code, on pycryptodome lib.